### PR TITLE
Fix Velocity plugin

### DIFF
--- a/Velocity/src/main/java/me/egg82/antivpn/VelocityBootstrap.java
+++ b/Velocity/src/main/java/me/egg82/antivpn/VelocityBootstrap.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.xml.xpath.XPathExpressionException;
 import me.egg82.antivpn.utils.LogUtil;
+import me.egg82.antivpn.utils.VelocityFakeClassLoader;
 import net.kyori.text.TextComponent;
 import net.kyori.text.format.TextColor;
 import ninja.egg82.maven.Artifact;
@@ -58,7 +59,10 @@ public class VelocityBootstrap {
     public VelocityBootstrap(ProxyServer proxy, PluginDescription description) {
         this.proxy = proxy;
         this.description = description;
+    }
 
+    @Subscribe(order = PostOrder.FIRST)
+    public void onEarlyInit(ProxyInitializeEvent event) {
         if (!description.getSource().isPresent()) {
             throw new RuntimeException("Could not get plugin file path.");
         }
@@ -66,7 +70,7 @@ public class VelocityBootstrap {
             throw new RuntimeException("Could not get plugin name.");
         }
 
-        proxiedClassLoader = new ProxiedURLClassLoader(getClass().getClassLoader(), new String[] { "org\\.slf4j\\..*", "com\\.mysql\\.jdbc\\..*" });
+        proxiedClassLoader = new VelocityFakeClassLoader(proxy, this);
 
         try {
             loadJars(new File(new File(description.getSource().get().getParent().toFile(), description.getName().get()), "external"), proxiedClassLoader);

--- a/Velocity/src/main/java/me/egg82/antivpn/utils/VelocityFakeClassLoader.java
+++ b/Velocity/src/main/java/me/egg82/antivpn/utils/VelocityFakeClassLoader.java
@@ -1,0 +1,24 @@
+package me.egg82.antivpn.utils;
+
+import com.velocitypowered.api.proxy.ProxyServer;
+import me.egg82.antivpn.VelocityBootstrap;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+
+public class VelocityFakeClassLoader extends URLClassLoader {
+    private final ProxyServer server;
+    private final VelocityBootstrap plugin;
+
+    public VelocityFakeClassLoader(ProxyServer server, VelocityBootstrap plugin) {
+        super(new URL[0], VelocityBootstrap.class.getClassLoader());
+        this.server = server;
+        this.plugin = plugin;
+    }
+
+    @Override
+    protected void addURL(URL url) {
+        server.getPluginManager().addToClasspath(plugin, Paths.get(url.getPath()));
+    }
+}

--- a/Velocity/src/main/java/me/egg82/antivpn/utils/VelocityFakeClassLoader.java
+++ b/Velocity/src/main/java/me/egg82/antivpn/utils/VelocityFakeClassLoader.java
@@ -3,8 +3,10 @@ package me.egg82.antivpn.utils;
 import com.velocitypowered.api.proxy.ProxyServer;
 import me.egg82.antivpn.VelocityBootstrap;
 
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class VelocityFakeClassLoader extends URLClassLoader {
@@ -19,6 +21,12 @@ public class VelocityFakeClassLoader extends URLClassLoader {
 
     @Override
     protected void addURL(URL url) {
-        server.getPluginManager().addToClasspath(plugin, Paths.get(url.getPath()));
+        Path path;
+        try {
+            path = Paths.get(url.toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Unable to add URL to plugin classloader", e);
+        }
+        server.getPluginManager().addToClasspath(plugin, path);
     }
 }


### PR DESCRIPTION
AntiVPN tries to load dependencies in an independent class loader. This is not well-supported in Velocity, but Velocity allows any plugin to inject files into their own classpath. As a quick fix, implement a fake `URLClassLoader` that just forwards to Velocity's `PluginManager#addToClasspath()`. A longer-term fix would be to use a solution similar to LuckPerms's solution.

This fix has only been tested on Linux, I'm not sure how well Windows will respond. I have validated some basic plugin functionality (`/antivpn check <ip>` works, and players can join the proxy).