### PR TITLE
Fix pom.xml files

### DIFF
--- a/Bungee/pom.xml
+++ b/Bungee/pom.xml
@@ -227,11 +227,10 @@
             <id>papermc-snpashots</id>
             <url>https://papermc.io/repo/repository/maven-snapshots/</url>
         </repository>
-        <!--<repository>
+        <repository>
             <id>bungeecord-repo</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>-->
-
+        </repository>
         <repository>
             <id>egg82-nexus</id>
             <url>https://nexus.egg82.me/repository/maven-releases/</url>
@@ -245,13 +244,13 @@
             <url>https://repo.aikar.co/content/groups/aikar/</url>
         </repository>
 
+        <repository> <!-- for development builds -->
+            <id>sonatype-oss-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
         <repository>
             <id>github-rjenkinsjr</id>
             <url>https://raw.github.com/rjenkinsjr/maven2/repo</url>
-        </repository>
-        <repository>
-            <id>plan</id>
-            <url>https://dl.bintray.com/rsl1122/Plan-repository</url>
         </repository>
         <repository>
             <id>CodeMC</id>
@@ -291,7 +290,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bungeecord</artifactId>
-            <version>${adventure.version}</version>
+            <version>${adventure.bungeecord.version}</version>
         </dependency>
         <dependency>
             <groupId>ninja.egg82</groupId>
@@ -322,10 +321,9 @@
             <version>${bstats.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.djrapitops</groupId>
-            <artifactId>Plan-api</artifactId>
+            <groupId>com.github.plan-player-analytics</groupId>
+            <artifactId>Plan</artifactId>
             <version>${plan.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.luckperms</groupId>
@@ -347,7 +345,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>${adventure.version}</version>
+            <version>${minimessage.version}</version>
         </dependency>
         <dependency>
             <groupId>net.oneandone.reflections8</groupId>

--- a/Spigot/pom.xml
+++ b/Spigot/pom.xml
@@ -259,10 +259,6 @@
             <url>https://raw.github.com/rjenkinsjr/maven2/repo</url>
         </repository>
         <repository>
-            <id>plan</id>
-            <url>https://dl.bintray.com/rsl1122/Plan-repository</url>
-        </repository>
-        <repository>
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
@@ -334,10 +330,9 @@
             <version>${bstats.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.djrapitops</groupId>
-            <artifactId>Plan-api</artifactId>
+            <groupId>com.github.plan-player-analytics</groupId>
+            <artifactId>Plan</artifactId>
             <version>${plan.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>

--- a/Velocity/pom.xml
+++ b/Velocity/pom.xml
@@ -247,10 +247,6 @@
             <url>https://raw.github.com/rjenkinsjr/maven2/repo</url>
         </repository>
         <repository>
-            <id>plan</id>
-            <url>https://dl.bintray.com/rsl1122/Plan-repository</url>
-        </repository>
-        <repository>
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
@@ -303,10 +299,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.djrapitops</groupId>
-            <artifactId>Plan-api</artifactId>
+            <groupId>com.github.plan-player-analytics</groupId>
+            <artifactId>Plan</artifactId>
             <version>${plan.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.luckperms</groupId>
@@ -326,9 +321,14 @@
 
         <!-- common -->
         <dependency>
+            <groupId>co.aikar</groupId>
+            <artifactId>acf-velocity</artifactId>
+            <version>${acf.version}</version>
+        </dependency>
+        <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>${adventure.version}</version>
+            <version>${minimessage.version}</version>
         </dependency>
         <dependency>
             <groupId>net.oneandone.reflections8</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <ebean.version>12.7.2</ebean.version>
         <hikari.version>4.0.3</hikari.version>
         <flexjson.version>3.3</flexjson.version>
-        <kyori-event.version>3.0.0</kyori-event.version>
+        <kyori-event.version>4.0.0-SNAPSHOT</kyori-event.version>
         <jedis.version>3.5.1</jedis.version>
         <rabbitmq.version>5.11.0</rabbitmq.version>
         <nats.version>2.8.0</nats.version>
@@ -41,11 +41,13 @@
         <netty.version>4.1.50.Final</netty.version> <!-- keep this updated with Paper: https://github.com/PaperMC/Paper/blob/d3dc24999e0a1e8f3e8d9d59a36f32261a52a498/Spigot-Server-Patches/0001-POM-Changes.patch -->
         <jetbrains.version>20.1.0</jetbrains.version>
         <junit.version>5.8.0-M1</junit.version>
+        <mbassador.version>1.3.1</mbassador.version>
 
         <cloud.version>1.4.0</cloud.version>
         <commodore.version>1.9</commodore.version>
         <adventure.version>4.7.0</adventure.version> <!-- keep updated with Paper: https://github.com/PaperMC/Paper/blob/master/Spigot-API-Patches/0005-Adventure.patch -->
         <adventure.bukkit.version>4.0.0-SNAPSHOT</adventure.bukkit.version>
+        <adventure.bungeecord.version>4.0.0-SNAPSHOT</adventure.bungeecord.version>
         <minimessage.version>4.1.0-SNAPSHOT</minimessage.version>
         <eventchain.api.version>2.1.0</eventchain.api.version>
         <eventchain.version>3.1.2</eventchain.version>
@@ -54,6 +56,8 @@
         <relocator.version>1.4</relocator.version>
         <reflections.version>0.11.7</reflections.version>
         <javassist.version>3.27.0-GA</javassist.version>
+        <depdownloader.version>2.2.16</depdownloader.version>
+        <acf.version>0.5.1-SNAPSHOT</acf.version> <!-- Must be compiled manually and installed to local repo: https://github.com/aikar/commands -->
 
         <plan.version>5.4.1330</plan.version>
         <placeholderapi.version>2.10.9</placeholderapi.version>
@@ -187,8 +191,8 @@
         <module>API</module>
         <module>Common</module>
         <module>Paper</module>
-        <!--<module>Spigot</module>-->
-        <!--<module>Bungee</module>
-        <module>Velocity</module>-->
+        <module>Spigot</module>
+        <module>Bungee</module>
+        <module>Velocity</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -191,8 +191,10 @@
         <module>API</module>
         <module>Common</module>
         <module>Paper</module>
+        <!--
         <module>Spigot</module>
         <module>Bungee</module>
         <module>Velocity</module>
+        -->
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <relocator.version>1.4</relocator.version>
         <reflections.version>0.11.7</reflections.version>
         <javassist.version>3.27.0-GA</javassist.version>
-        <depdownloader.version>2.2.16</depdownloader.version>
+        <depdownloader.version>2.2.16</depdownloader.version> <!-- Must be compiled manually and installed to local repo: https://github.com/egg82/DepDownloader -->
         <acf.version>0.5.1-SNAPSHOT</acf.version> <!-- Must be compiled manually and installed to local repo: https://github.com/aikar/commands -->
 
         <plan.version>5.4.1330</plan.version>


### PR DESCRIPTION
- Enable Spigot, Velocity, and Bungee modules
- Add version variables for DepDownloader and ACF, with comments explaining that these must be manually compiled and installed in your local repository
- Added version variables for Adventure-Bungeecord and MBassador
- Update Kyori version variable
- Fix Plan repositories and dependencies in Bungeecord, Spigot, and Velocity modules
- Replaced ```${adventure.version}``` with appropriate ```${minimessage.version}``` for Minimessage dependency in Velocity and Bungeecord modules

Hope this PR helps a bit! Looking forward to a more perfect plugin!